### PR TITLE
feat: implement halt, exit, write, and create syscalls

### DIFF
--- a/pintos/lib/user/syscall.c
+++ b/pintos/lib/user/syscall.c
@@ -28,7 +28,6 @@ static __inline int64_t syscall (uint64_t num_, uint64_t a1_, uint64_t a2_,
 			: "cc", "memory");
 	return ret;
 }
-
 /* Invokes syscall NUMBER, passing no arguments, and returns the
    return value as an `int'. */
 #define syscall0(NUMBER) ( \

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -519,7 +519,8 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->locked_by = NULL;
 
 #ifdef USERPROG
-	t->fd_table = palloc_get_page (PAL_ZERO);
+	// t->fd_table = palloc_get_page (PAL_ZERO);
+	t->fd_table = NULL;
 	t->next_fd = 2;
 #endif
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -14,18 +14,18 @@
 #include "threads/vaddr.h"
 #include "threads/mmu.h"
 #include "userprog/process.h"
+#include "filesys/filesys.h"
 
-void syscall_entry (void);
-void syscall_handler (struct intr_frame *);
+void syscall_entry(void);
+void syscall_handler(struct intr_frame *);
 
 /* 추가 함수들 */
-void halt (void);
-void exit (int status);
-int write (int fd, const void *buffer, unsigned size);
-bool create (const char *file, unsigned initial_size);
+void halt(void);
+void exit(int status);
+int write(int fd, const void *buffer, unsigned size);
+bool create(const char *file, unsigned initial_size);
 
-void check_address (void *addr);
-
+void check_address(void *addr);
 
 struct lock filesys_lock;
 
@@ -53,177 +53,126 @@ struct lock filesys_lock;
  */
 #define MSR_SYSCALL_MASK 0xc0000084
 
-void
-syscall_init (void) {
-	write_msr (MSR_STAR, ((uint64_t) SEL_UCSEG - 0x10) << 48 |
-	                             ((uint64_t) SEL_KCSEG) << 32);
-	write_msr (MSR_LSTAR, (uint64_t) syscall_entry);
+void syscall_init(void)
+{
+	write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48 |
+							((uint64_t)SEL_KCSEG) << 32);
+	write_msr(MSR_LSTAR, (uint64_t)syscall_entry);
 
 	/*
 	 * 인터럽트 서비스 루틴은 syscall_entry가 유저랜드 스택을 커널 모드
 	 * 스택으로 교체하기 전까지 어떤 인터럽트도 처리해서는 안 된다. 따라서
 	 * FLAG_FL을 마스킹했다.
 	 */
-	write_msr (MSR_SYSCALL_MASK,
-	           FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+	write_msr(MSR_SYSCALL_MASK,
+			  FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 
-	lock_init (&filesys_lock);
+	lock_init(&filesys_lock);
 }
 
 /*
  * 메인 시스템 콜 인터페이스.
  */
 // 현재 실행중이던 유저 스레드/프로세스가 커널로 넘어올 때 저장된 CPU 레지스터들
-void
-syscall_handler (struct intr_frame *f UNUSED) { 
-	switch (f->R.rax) {
+void syscall_handler(struct intr_frame *f UNUSED)
+{
+	switch (f->R.rax)
+	{
 	case SYS_HALT:
-		halt ();
+		halt();
 		break;
 	case SYS_WRITE:
-		/* fd, buffer, size를 전달받는다. */	
-		f->R.rax = write (f->R.rdi, f->R.rsi, f->R.rdx);
+		/* fd, buffer, size를 전달받는다. */
+		f->R.rax = write(f->R.rdi, f->R.rsi, f->R.rdx);
 		break;
 	case SYS_EXIT:
 		/* 종료 상태값 받음 */
-		exit (f->R.rdi);
+		exit(f->R.rdi);
 		break;
 	case SYS_CREATE:
-		
-	//open
-	//remove
+		f->R.rax = create(f->R.rdi, f->R.rsi);
+		break;
+		// open
+		// close
+		// remove
 
 	default:
 		break;
 	}
 }
 
-void
-halt (void) {
+void halt(void)
+{
 	// pintos 실행 중인 가상 머신 자체가 꺼진다
-	power_off ();
+	power_off();
 }
 
-
-// 현재 사용자 프로그램을 종료하고 status커널로 돌아갑니다. 
-// 프로세스의 부모 wait프로세스가 해당 프로세스에 대해 종료를 요청한 경우(아래 참조), 이 상태가 반환됩니다. 
-// 일반적으로 0은 status성공 
-//0을 나타내고 0이 아닌 값은 오류를 나타냅니다.
-void exit(int status){ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
+// 현재 사용자 프로그램을 종료하고 status커널로 돌아갑니다.
+// 프로세스의 부모 wait프로세스가 해당 프로세스에 대해 종료를 요청한 경우(아래 참조), 이 상태가 반환됩니다.
+// 일반적으로 0은 status성공
+// 0을 나타내고 0이 아닌 값은 오류를 나타냅니다.
+void exit(int status)
+{ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
 	printf("%s: exit(%d)\n", thread_current()->name, status);
 
-	//현재 스레드를 죽인다
+	// 현재 스레드를 죽인다
 	thread_exit();
 }
 
-
-
-//buffer 시작 주소에서 size만큼 읽어서 stdout 콘솔에 출력해라
-//그리고  size 반환
-int write(int fd, const void * buffer, unsigned size)
+// buffer 시작 주소에서 size만큼 읽어서 stdout 콘솔에 출력해라
+// 그리고  size 반환
+int write(int fd, const void *buffer, unsigned size)
 {
 	// size가 0일때 아무것도 읽지 않는다는 거기 때문에 그냥 0반환
-	if(size == 0)
+	if (size == 0)
 	{
 		return 0;
 	}
 
 	// write가 읽기 시작할 데이터의 첫 바이트 주소
-	if(buffer == NULL)
+	if (buffer == NULL)
 	{
-		//유저 프로그램 종료
+		// 유저 프로그램 종료
 		exit(-1);
 	}
 
 	// buffer가 유저 주소 범위인가?
-	if(!is_user_vaddr(buffer))
+	if (!is_user_vaddr(buffer))
 	{
-		//유저 프로그램 종료
+		// 유저 프로그램 종료
 		exit(-1);
 	}
 
-	if(fd == 1)
+	if (fd == 1)
 	{
 		putbuf(buffer, size);
 		return size;
 	}
-	
-	if(fd == 0 || fd > 1)
+
+	if (fd == 0 || fd > 1)
 	{
 		return -1;
 	}
 
-
 	return size;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// int
-// write (int fd, const void *buffer, unsigned size) {
-// 	int write_result;
-
-// 	/* 유효성 검사 로직 */
-// 	check_address (buffer);
-
-// 	/* 락 획득: 동시에 읽어서 꼬임 방지*/
-// 	lock_acquire (&filesys_lock);
-
-// 	/* 명령: 화면에 출력하라 */
-// 	if (fd == 1) {
-// 		putbuf (buffer, size);
-// 		write_result = size;
-// 	}
-// 	/* 명령: 기타... */
-// 	else {
-// 		/* 임시로 실패 처리 */
-// 		write_result = -1;
-// 	}
-
-// 	/* 락 해제: 이제 읽을 필요 없음 */
-// 	lock_release (&filesys_lock);
-
-// 	return write_result;
-// }
-
-void
-check_address (void *addr) {
-	/* 애초에 없다면? */
-	if (addr == NULL) {
-		exit (-1);
+// file 초기 크기가 바이트인 새 파일을 생성합니다 initial_size.
+// 성공하면 true, 실패하면 false를 반환합니다.
+// 새 파일을 생성하는 것만으로는 파일을 열 수 없습니다.
+// 새 파일을 여는 것은 별도의 작업이며 open 시스템 호출이 필요합니다.
+bool create(const char *file, unsigned initial_size)
+{
+	if (file == NULL)
+	{
+		return false;
 	}
 
-	/* 커널 영역 침범 여부 */
-	if (!is_user_vaddr (addr)) {
-		exit (-1);
+	// file이라는 주소가 유저 영역 주소가 아니면
+	if (!is_user_vaddr(file))
+	{
+		return false;
 	}
+
+	return filesys_create(file, initial_size);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -22,7 +22,10 @@ void syscall_handler (struct intr_frame *);
 void halt (void);
 void exit (int status);
 int write (int fd, const void *buffer, unsigned size);
+bool create (const char *file, unsigned initial_size);
+
 void check_address (void *addr);
+
 
 struct lock filesys_lock;
 
@@ -85,6 +88,8 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		/* 종료 상태값 받음 */
 		exit (f->R.rdi);
 		break;
+	case SYS_CREATE:
+		
 	//open
 	//remove
 
@@ -105,23 +110,12 @@ halt (void) {
 // 일반적으로 0은 status성공 
 //0을 나타내고 0이 아닌 값은 오류를 나타냅니다.
 void exit(int status){ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
-	printf("current thread : %s, exit(status) : %d", thread_current()->name, status);
+	printf("%s: exit(%d)\n", thread_current()->name, status);
 
 	//현재 스레드를 죽인다
 	thread_exit();
 }
 
-
-
-
-
-
-
-// void
-// exit (int status) {
-// 	printf ("%s: exit(%d)\n", thread_current ()->name, status);
-// 	thread_exit ();
-// }
 
 
 //buffer 시작 주소에서 size만큼 읽어서 stdout 콘솔에 출력해라

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -70,20 +70,24 @@ syscall_init (void) {
 /*
  * 메인 시스템 콜 인터페이스.
  */
+// 현재 실행중이던 유저 스레드/프로세스가 커널로 넘어올 때 저장된 CPU 레지스터들
 void
-syscall_handler (struct intr_frame *f UNUSED) {
+syscall_handler (struct intr_frame *f UNUSED) { 
 	switch (f->R.rax) {
 	case SYS_HALT:
 		halt ();
 		break;
 	case SYS_WRITE:
-		/* fd, buffer, size를 전달받는다. */
+		/* fd, buffer, size를 전달받는다. */	
 		f->R.rax = write (f->R.rdi, f->R.rsi, f->R.rdx);
 		break;
 	case SYS_EXIT:
 		/* 종료 상태값 받음 */
 		exit (f->R.rdi);
 		break;
+	//open
+	//remove
+
 	default:
 		break;
 	}
@@ -91,42 +95,131 @@ syscall_handler (struct intr_frame *f UNUSED) {
 
 void
 halt (void) {
+	// pintos 실행 중인 가상 머신 자체가 꺼진다
 	power_off ();
 }
 
-void
-exit (int status) {
-	printf ("%s: exit(%d)\n", thread_current ()->name, status);
-	thread_exit ();
+
+// 현재 사용자 프로그램을 종료하고 status커널로 돌아갑니다. 
+// 프로세스의 부모 wait프로세스가 해당 프로세스에 대해 종료를 요청한 경우(아래 참조), 이 상태가 반환됩니다. 
+// 일반적으로 0은 status성공 
+//0을 나타내고 0이 아닌 값은 오류를 나타냅니다.
+// void exit(int status){ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
+// 	printf("current thread : %s, exit(status) : %d", thread_current()->name, status);
+
+// 	//현재 스레드를 죽인다
+// 	thread_exit();
+// }
+
+
+
+
+
+
+
+// void
+// exit (int status) {
+// 	printf ("%s: exit(%d)\n", thread_current ()->name, status);
+// 	thread_exit ();
+// }
+
+
+//buffer 시작 주소에서 size만큼 읽어서 stdout 콘솔에 출력해라
+//그리고  size 반환
+int write(int fd, const void * buffer, unsigned size)
+{
+	// size가 0일때 아무것도 읽지 않는다는 거기 때문에 그냥 0반환
+	if(size == 0)
+	{
+		return 0;
+	}
+
+	// write가 읽기 시작할 데이터의 첫 바이트 주소
+	if(buffer == NULL)
+	{
+		//유저 프로그램 종료
+		exit(-1);
+	}
+
+	// buffer가 유저 주소 범위인가?
+	if(!is_user_vaddr(buffer))
+	{
+		//유저 프로그램 종료
+		exit(-1);
+	}
+
+	if(fd == 1)
+	{
+		putbuf(buffer, size);
+		return size;
+	}
+	
+	if(fd == 0 || fd > 1)
+	{
+		return -1;
+	}
+
+
+	return size;
 }
 
 
-int
-write (int fd, const void *buffer, unsigned size) {
-	int write_result;
 
-	/* 유효성 검사 로직 */
-	check_address (buffer);
 
-	/* 락 획득: 동시에 읽어서 꼬임 방지*/
-	lock_acquire (&filesys_lock);
 
-	/* 명령: 화면에 출력하라 */
-	if (fd == 1) {
-		putbuf (buffer, size);
-		write_result = size;
-	}
-	/* 명령: 기타... */
-	else {
-		/* 임시로 실패 처리 */
-		write_result = -1;
-	}
 
-	/* 락 해제: 이제 읽을 필요 없음 */
-	lock_release (&filesys_lock);
 
-	return write_result;
-}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// int
+// write (int fd, const void *buffer, unsigned size) {
+// 	int write_result;
+
+// 	/* 유효성 검사 로직 */
+// 	check_address (buffer);
+
+// 	/* 락 획득: 동시에 읽어서 꼬임 방지*/
+// 	lock_acquire (&filesys_lock);
+
+// 	/* 명령: 화면에 출력하라 */
+// 	if (fd == 1) {
+// 		putbuf (buffer, size);
+// 		write_result = size;
+// 	}
+// 	/* 명령: 기타... */
+// 	else {
+// 		/* 임시로 실패 처리 */
+// 		write_result = -1;
+// 	}
+
+// 	/* 락 해제: 이제 읽을 필요 없음 */
+// 	lock_release (&filesys_lock);
+
+// 	return write_result;
+// }
 
 void
 check_address (void *addr) {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -104,12 +104,12 @@ halt (void) {
 // 프로세스의 부모 wait프로세스가 해당 프로세스에 대해 종료를 요청한 경우(아래 참조), 이 상태가 반환됩니다. 
 // 일반적으로 0은 status성공 
 //0을 나타내고 0이 아닌 값은 오류를 나타냅니다.
-// void exit(int status){ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
-// 	printf("current thread : %s, exit(status) : %d", thread_current()->name, status);
+void exit(int status){ // status는 프로그램이 끝나면서 남기는 결과값, 0은 정상, -1 실패
+	printf("current thread : %s, exit(status) : %d", thread_current()->name, status);
 
-// 	//현재 스레드를 죽인다
-// 	thread_exit();
-// }
+	//현재 스레드를 죽인다
+	thread_exit();
+}
 
 
 


### PR DESCRIPTION
## Summary
이번 PR에서는 기본 시스템콜인 `halt`, `exit`, `write`, `create`를 구현했습니다.

## Implemented
- `SYS_HALT`
- `SYS_EXIT`
- `SYS_WRITE`
- `SYS_CREATE`

## Details
- `halt`는 Pintos를 종료합니다.
- `exit`는 종료 상태를 출력하고 현재 스레드를 종료합니다.
- `write`는 현재 `stdout(fd=1)` 출력을 지원합니다.
- `create`는 파일 이름과 초기 크기를 받아 파일을 생성합니다.

## Remaining Work
- `open`
- `read`
- `close`
- fd table 기반 파일 입출력
- 더 안전한 user pointer validation
