### PR TITLE
feat: 포크 및 프로세스 관련 테스트 문서 추가

### DIFF
--- a/pintos-project2-process-tests.md
+++ b/pintos-project2-process-tests.md
@@ -1,0 +1,150 @@
+# PintOS Project 2 — 포크/프로세스 관련 테스트 분류
+
+> 전체 66개 테스트 중 포크·exec·wait·프로세스 라이프사이클과 관련된 항목만 추출.
+> 파일 시스콜 전용 테스트(Create, Open, Close, Read, Write)는 제외.
+
+## 담당 범위 요약
+
+| 카테고리 | 테스트 수 | 필요 syscall |
+|----------|-----------|-------------|
+| Fork | 6 | fork, wait, exit (+일부 file ops) |
+| Exec | 6 | fork, wait, exec |
+| Wait | 4 | fork, wait, exit, exec |
+| Multi | 2 | fork, wait, exec, open, close |
+| ROX (프로세스 관련) | 2 | fork, wait, exec, open, write |
+| No-VM | 1 | fork, wait, exit |
+| **합계** | **21** | |
+
+---
+
+## Fork (6개)
+
+### fork-once
+- 단일 자식을 fork하고 wait한다.
+- 필요: fork, wait, exit
+
+### fork-multiple
+- fork_and_wait()를 4번 순차 호출한다. 매번 magic 값을 증가시키고 자식이 해당 값으로 exit한다.
+- 필요: fork, wait, exit
+
+### fork-recursive
+- 재귀적으로 fork한다. magic이 10 이상이면 exit, 아니면 자식이 다시 fork_and_wait를 호출한다.
+- 필요: fork, wait, exit
+
+### fork-read
+- 부모가 파일을 open한 뒤 fork한다. 자식이 같은 fd로 read/close한다. 부모는 wait 후 해당 fd에 다시 접근하여 파일 핸들 독립성을 검증한다.
+- 필요: fork, wait, exit, open, read, close, seek
+- 참고: fd_table 복제(file_duplicate)가 올바르게 동작해야 통과
+
+### fork-close
+- fork-read와 유사. 자식이 fd를 close한 후, 부모가 같은 fd로 접근할 수 있는지 확인한다.
+- 필요: fork, wait, exit, open, close, seek
+
+### fork-boundary
+- 프로세스 이름이 페이지 경계를 걸치는 경우의 fork 동작을 테스트한다.
+- 필요: fork, wait, exit
+
+---
+
+## Exec (6개)
+
+### exec-once
+- exec으로 자식 프로세스를 실행하고 wait한다.
+- 필요: fork, wait, exec
+
+### exec-arg
+- exec에 인자를 전달하고 자식이 인자를 올바르게 받는지 검증한다.
+- 필요: fork, wait, exec
+
+### exec-boundary
+- exec할 파일 이름이 페이지 경계를 걸치는 경우를 테스트한다.
+- 필요: fork, wait, exec
+
+### exec-missing
+- 존재하지 않는 프로그램을 exec하면 -1을 반환해야 한다.
+- 필요: exec
+
+### exec-bad-ptr
+- 유효하지 않은 포인터를 exec에 전달하면 프로세스가 -1로 종료해야 한다.
+- 필요: exec
+
+### exec-read
+- 파일을 open/read한 뒤 exec한다. exec 후 이전 메모리가 교체되는지 확인한다.
+- 필요: open, read, seek, exec, fork, wait
+
+---
+
+## Wait (4개)
+
+### wait-simple
+- fork 후 exec하고, 부모가 wait하여 자식의 종료 코드를 받는다.
+- 필요: fork, wait, exit, exec
+
+### wait-twice
+- 같은 자식에 wait를 두 번 호출한다. 첫 번째는 종료 코드(81) 반환, 두 번째는 -1 반환.
+- 필요: fork, wait, exit, exec
+- 참고: list_remove 후 재탐색 실패가 올바르게 동작해야 통과
+
+### wait-killed
+- 비정상 종료(exception)하는 자식을 wait한다. -1이 반환되어야 한다.
+- 필요: fork, wait, exit, exec
+- 참고: exception handler에서 exit(-1) 호출이 필요
+
+### wait-bad-pid
+- 존재하지 않는 PID로 wait하면 -1을 반환해야 한다.
+- 필요: wait
+
+---
+
+## Multi (2개)
+
+### multi-recurse
+- 재귀적으로 자기 자신을 exec한다. depth 인자를 줄여가며 종료 코드를 전파한다.
+- 필요: fork, wait, exec
+
+### multi-child-fd
+- 부모가 파일을 open한 뒤 fork+exec한다. 자식이 부모의 fd를 close 시도한다. 파일 핸들이 상속되지 않아야 한다.
+- 필요: fork, wait, exec, open, close, read
+
+---
+
+## ROX — 프로세스 관련만 (2개)
+
+### rox-child
+- 자식 프로세스가 실행 중인 자기 자신의 바이너리에 write를 시도한다. 거부되어야 한다.
+- 필요: fork, wait, exec, open, read, write, seek
+- 참고: rox-simple은 fork 없이 단일 프로세스에서 테스트하므로 파일 시스콜 담당
+
+### rox-multichild
+- rox-child를 재귀적으로 5단계 깊이로 실행한다. 모든 단계에서 write 보호가 유지되어야 한다.
+- 필요: fork, wait, exec, open, read, write, seek
+
+---
+
+## No-VM (1개)
+
+### multi-oom
+- 메모리가 부족할 때까지 재귀적으로 fork한다. 최소 10회 depth를 달성해야 하고, 10번 반복하여 메모리 누수가 없는지 확인한다.
+- 필요: fork, wait, exit, open, close
+- 참고: 고아 해방 루프 + fd_table 해제가 완벽해야 통과. 가장 까다로운 테스트.
+
+---
+
+## 구현 의존성 정리
+
+### B1 (wait/exit 동기화) 단독으로 테스트 가능한 항목
+- wait-bad-pid: child_list 검색 실패 -> -1 반환만 확인
+- exec-missing: exec 실패 시 -1 반환
+
+### B1 + B2 합류 후 테스트 가능한 항목
+- fork-once, fork-multiple, fork-recursive, fork-boundary
+- wait-simple, wait-twice, wait-killed
+- exec-once, exec-arg, exec-boundary, exec-bad-ptr
+- multi-recurse
+
+### B1 + B2 + A (파일 시스콜) 합류 후 테스트 가능한 항목
+- fork-read, fork-close
+- exec-read
+- multi-child-fd
+- rox-child, rox-multichild
+- multi-oom (최종 통합 테스트)

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -27,6 +27,15 @@ enum thread_status {
  */
 typedef int tid_t;
 
+struct child_status {
+	tid_t tid;                 // 자식 스레드 식별자
+	int exit_status;           // 자식 종료 코드
+	bool waited;               // 부모가 이미 wait했는지 여부
+	bool exited;               // 자식이 이미 종료했는지 여부
+	struct semaphore wait_sema; // 자식 종료 알림용 세마포어
+	struct list_elem elem;     // 부모의 child_status_list 원소
+};
+
 /*
  * 스레드 이름 버퍼의 최대 크기.
  */
@@ -113,33 +122,20 @@ struct thread {
 	enum thread_status status;  // 현재 스케줄링 상태
 	int priority;               // 현재 유효 우선순위
 	int base_priority;          // 우선순위 기부 전 원래 우선순위
-	int exit_status;            // 프로세스 종료 코드
 	int64_t wake_tick;          // 깨워야 할 절대 tick
 	char name[THREAD_NAME_MAX]; // 디버깅용 이름
-	struct semaphore wait_sema; // 부모가 자식 종료를 기다릴 때 쓰는 세마포어
-	struct semaphore
-	        exit_sema;    // 부모가 자식 수거를 끝낼 때까지 기다리는 세마포어
-	struct list children; // 내가 만든 자식 스레드 목록
-	struct list_elem child_elem;    // 부모 children 리스트의 원소
 	struct list donation_list;      // 나에게 우선순위를 기부한 스레드 목록
 	struct list_elem donation_elem; // 다른 스레드 donation_list의 원소
 	struct lock *waiting_lock;      // 현재 기다리는 락, 우선순위 기부 전파용
 	struct list_elem elem;          // ready_list 또는 semaphore waiters의 원소
 
 #ifdef USERPROG
-	/*
-	 * userprog/process.c가 소유한다.
-	 */
-	/*
-	 * 페이지 맵 레벨 4.
-	 */
-	uint64_t *pml4;
+	uint64_t *pml4;                     // userprog/process.c가 소유하는 페이지 맵 레벨 4
 
-	/* 파일 디스크립터 테이블 (palloc 페이지, 최대 512개).
-	 * 인덱스 0 = stdin(예약), 1 = stdout(예약), 2부터 사용. */
-	struct file **fd_table;
-	/* 다음에 할당할 fd 번호. */
-	int next_fd;
+	struct file **fd_table;              // 파일 디스크립터 테이블
+	int next_fd;                         // 다음에 할당할 fd 번호
+	struct list child_status_list;       // 부모가 소유하는 자식 상태 레코드 목록
+	struct child_status *self_status;    // 현재 스레드 자신의 child_status
 #endif
 #ifdef VM
 	/*

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -1,11 +1,17 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 
+// @warn [C/C++] #include 오류가 검색되었습니다. includePath를 업데이트하세요.
+// 이 변환 단위(/Users/woonyong/workspace/Krafton-Jungle/SW_AI-W
+// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "debug.h"
 #include <debug.h>
+// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "list.h"
 #include <list.h>
 #include <stdint.h>
+// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "threads/interrupt.h"
 #include "threads/interrupt.h"
 /* 임시 해결용 */
+// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "threads/synch.h"
 #include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
@@ -28,12 +34,12 @@ enum thread_status {
 typedef int tid_t;
 
 struct child_status {
-	tid_t tid;                 // 자식 스레드 식별자
-	int exit_status;           // 자식 종료 코드
-	bool waited;               // 부모가 이미 wait했는지 여부
-	bool exited;               // 자식이 이미 종료했는지 여부
+	tid_t tid;                  // 자식 스레드 식별자
+	int exit_status;            // 자식 종료 코드
+	bool waited;                // 부모가 이미 wait했는지 여부
+	bool exited;                // 자식이 이미 종료했는지 여부
 	struct semaphore wait_sema; // 자식 종료 알림용 세마포어
-	struct list_elem elem;     // 부모의 child_status_list 원소
+	struct list_elem elem;      // 부모의 child_status_list 원소
 };
 
 /*
@@ -118,24 +124,24 @@ struct child_status {
  * semaphore 대기 리스트에 있기 때문이다.
  */
 struct thread {
-	tid_t tid;                  // 스레드 식별자
-	enum thread_status status;  // 현재 스케줄링 상태
-	int priority;               // 현재 유효 우선순위
-	int base_priority;          // 우선순위 기부 전 원래 우선순위
-	int64_t wake_tick;          // 깨워야 할 절대 tick
-	char name[THREAD_NAME_MAX]; // 디버깅용 이름
+	tid_t tid;                      // 스레드 식별자
+	enum thread_status status;      // 현재 스케줄링 상태
+	int priority;                   // 현재 유효 우선순위
+	int base_priority               // 우선순위 기부 전 원래 우선순위
+	        int64_t wake_tick;      // 깨워야 할 절대 tick
+	char name[THREAD_NAME_MAX];     // 디버깅용 이름
 	struct list donation_list;      // 나에게 우선순위를 기부한 스레드 목록
 	struct list_elem donation_elem; // 다른 스레드 donation_list의 원소
 	struct lock *waiting_lock;      // 현재 기다리는 락, 우선순위 기부 전파용
 	struct list_elem elem;          // ready_list 또는 semaphore waiters의 원소
 
 #ifdef USERPROG
-	uint64_t *pml4;                     // userprog/process.c가 소유하는 페이지 맵 레벨 4
+	uint64_t *pml4; // userprog/process.c가 소유하는 페이지 맵 레벨 4
 
-	struct file **fd_table;              // 파일 디스크립터 테이블
-	int next_fd;                         // 다음에 할당할 fd 번호
-	struct list child_status_list;       // 부모가 소유하는 자식 상태 레코드 목록
-	struct child_status *self_status;    // 현재 스레드 자신의 child_status
+	struct file **fd_table;           // 파일 디스크립터 테이블
+	int next_fd;                      // 다음에 할당할 fd 번호
+	struct list child_status_list;    // 부모가 소유하는 자식 상태 레코드 목록
+	struct child_status *self_status; // 현재 스레드 자신의 child_status
 #endif
 #ifdef VM
 	/*

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -15,22 +15,10 @@
  * 스레드 생애 주기의 상태들.
  */
 enum thread_status {
-	/*
-	 * 실행 중인 스레드.
-	 */
-	THREAD_RUNNING,
-	/*
-	 * 실행 중은 아니지만 실행될 준비가 된 상태.
-	 */
-	THREAD_READY,
-	/*
-	 * 어떤 이벤트가 발생하기를 기다리는 상태.
-	 */
-	THREAD_BLOCKED,
-	/*
-	 * 곧 파괴될 상태.
-	 */
-	THREAD_DYING
+	THREAD_RUNNING, // 실행 중인 스레드
+	THREAD_READY,   // 실행 중은 아니지만 실행될 준비가 된 상태
+	THREAD_BLOCKED, // 어떤 이벤트가 발생하기를 기다리는 상태
+	THREAD_DYING    // 곧 파괴될 상태
 };
 
 /*
@@ -121,45 +109,22 @@ typedef int tid_t;
  * semaphore 대기 리스트에 있기 때문이다.
  */
 struct thread {
-	/*
-	 * thread.c가 소유한다.
-	 */
-	/*
-	 * 스레드 식별자.
-	 */
-	tid_t tid;
-	/*
-	 * 스레드 상태.
-	 */
-	enum thread_status status;
-	/*
-	 * 이름(디버깅 목적).
-	 */
-	char name[THREAD_NAME_MAX];
-	/*
-	 * 우선순위.
-	 */
-	int priority;
-	/* 변하지 않는 원래 우선순위를 저장한다. */
-	int base_priority;
-	/* 스레드를 언제 깨울지 나타내는 tick 값이다. */
-	int64_t wake_tick;
-
-	// struct semaphore wait_sema;
-	// int exit_status;
-
-	/* donation-multiple 구현을 위한 필드들이다. */
-	struct list donation_list;
-	struct list_elem d_elem;
-	struct lock *locked_by;
-
-	/*
-	 * thread.c와 synch.c가 공유한다.
-	 */
-	/*
-	 * 리스트 원소.
-	 */
-	struct list_elem elem;
+	tid_t tid;                  // 스레드 식별자
+	enum thread_status status;  // 현재 스케줄링 상태
+	int priority;               // 현재 유효 우선순위
+	int base_priority;          // 우선순위 기부 전 원래 우선순위
+	int exit_status;            // 프로세스 종료 코드
+	int64_t wake_tick;          // 깨워야 할 절대 tick
+	char name[THREAD_NAME_MAX]; // 디버깅용 이름
+	struct semaphore wait_sema; // 부모가 자식 종료를 기다릴 때 쓰는 세마포어
+	struct semaphore
+	        exit_sema;    // 부모가 자식 수거를 끝낼 때까지 기다리는 세마포어
+	struct list children; // 내가 만든 자식 스레드 목록
+	struct list_elem child_elem;    // 부모 children 리스트의 원소
+	struct list donation_list;      // 나에게 우선순위를 기부한 스레드 목록
+	struct list_elem donation_elem; // 다른 스레드 donation_list의 원소
+	struct lock *waiting_lock;      // 현재 기다리는 락, 우선순위 기부 전파용
+	struct list_elem elem;          // ready_list 또는 semaphore waiters의 원소
 
 #ifdef USERPROG
 	/*
@@ -182,18 +147,8 @@ struct thread {
 	 */
 	struct supplemental_page_table spt;
 #endif
-
-	/*
-	 * thread.c가 소유한다.
-	 */
-	/*
-	 * 문맥 전환에 필요한 정보.
-	 */
-	struct intr_frame tf;
-	/*
-	 * 스택 오버플로우를 감지한다.
-	 */
-	unsigned magic;
+	struct intr_frame tf; // 문맥 전환에 필요한 레지스터 문맥
+	unsigned magic;       // 스택 오버플로우 감지용 마법값
 };
 
 /*
@@ -243,7 +198,7 @@ void check_preemption (void);
 void refresh_priority (struct thread *t);
 bool thread_priority (const struct list_elem *a, const struct list_elem *b,
                       void *aux);
-bool thread_priority_d_elem (const struct list_elem *a,
-                             const struct list_elem *b, void *aux);
+bool thread_priority_donation_elem (const struct list_elem *a,
+                                    const struct list_elem *b, void *aux);
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -1,17 +1,10 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 
-// @warn [C/C++] #include 오류가 검색되었습니다. includePath를 업데이트하세요.
-// 이 변환 단위(/Users/woonyong/workspace/Krafton-Jungle/SW_AI-W
-// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "debug.h"
 #include <debug.h>
-// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "list.h"
 #include <list.h>
 #include <stdint.h>
-// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "threads/interrupt.h"
 #include "threads/interrupt.h"
-/* 임시 해결용 */
-// @warn [C/C++] 파일 소스을(를) 열 수 없습니다. "threads/synch.h"
 #include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
@@ -127,8 +120,8 @@ struct thread {
 	tid_t tid;                      // 스레드 식별자
 	enum thread_status status;      // 현재 스케줄링 상태
 	int priority;                   // 현재 유효 우선순위
-	int base_priority               // 우선순위 기부 전 원래 우선순위
-	        int64_t wake_tick;      // 깨워야 할 절대 tick
+	int base_priority;              // 우선순위 기부 전 원래 우선순위
+	int64_t wake_tick;              // 깨워야 할 절대 tick
 	char name[THREAD_NAME_MAX];     // 디버깅용 이름
 	struct list donation_list;      // 나에게 우선순위를 기부한 스레드 목록
 	struct list_elem donation_elem; // 다른 스레드 donation_list의 원소

--- a/pintos/lib/string.c
+++ b/pintos/lib/string.c
@@ -1,6 +1,10 @@
 #include <string.h>
 #include <debug.h>
 
+/* @note
+ * 겹치지 않는 SRC의 SIZE바이트를 DST로 복사한다.
+ * DST를 반환한다.
+ */
 void *
 memcpy (void *dst_, const void *src_, size_t size) {
 	unsigned char *dst = dst_;
@@ -15,6 +19,10 @@ memcpy (void *dst_, const void *src_, size_t size) {
 	return dst_;
 }
 
+/* @note
+ * 겹쳐도 되는 SRC의 SIZE바이트를 DST로 복사한다.
+ * DST를 반환한다.
+ */
 void *
 memmove (void *dst_, const void *src_, size_t size) {
 	unsigned char *dst = dst_;
@@ -36,6 +44,11 @@ memmove (void *dst_, const void *src_, size_t size) {
 	return dst;
 }
 
+/* @note
+ * A와 B의 SIZE바이트 블록을 비교해 처음으로 다른 바이트를 찾는다.
+ * A의 바이트가 더 크면 양수를, B의 바이트가 더 크면 음수를,
+ * 두 블록이 같으면 0을 반환한다.
+ */
 int
 memcmp (const void *a_, const void *b_, size_t size) {
 	const unsigned char *a = a_;
@@ -50,6 +63,11 @@ memcmp (const void *a_, const void *b_, size_t size) {
 	return 0;
 }
 
+/* @note
+ * 문자열 A와 B에서 처음으로 다른 문자를 찾는다.
+ * A의 문자(unsigned char 기준)가 더 크면 양수를,
+ * B의 문자가 더 크면 음수를, 두 문자열이 같으면 0을 반환한다.
+ */
 int
 strcmp (const char *a_, const char *b_) {
 	const unsigned char *a = (const unsigned char *) a_;
@@ -66,6 +84,11 @@ strcmp (const char *a_, const char *b_) {
 	return *a < *b ? -1 : *a > *b;
 }
 
+/* @note
+ * BLOCK부터 시작하는 처음 SIZE바이트에서 CH가 처음 나타나는 위치를
+ * 가리키는 포인터를 반환한다.
+ * BLOCK 안에 CH가 없으면 널 포인터를 반환한다.
+ */
 void *
 memchr (const void *block_, int ch_, size_t size) {
 	const unsigned char *block = block_;
@@ -80,6 +103,11 @@ memchr (const void *block_, int ch_, size_t size) {
 	return NULL;
 }
 
+/* @note
+ * STRING에서 C가 처음 나타나는 위치를 찾아 반환한다.
+ * C가 STRING에 없으면 널 포인터를 반환한다.
+ * C == '\0'이면 STRING 끝의 널 종료 문자를 가리키는 포인터를 반환한다.
+ */
 char *
 strchr (const char *string, int c_) {
 	char c = c_;
@@ -95,6 +123,10 @@ strchr (const char *string, int c_) {
 			string++;
 }
 
+/* @note
+ * STRING의 앞부분에서 STOP에 포함되지 않은 문자들로만 이루어진
+ * 초기 부분 문자열의 길이를 반환한다.
+ */
 size_t
 strcspn (const char *string, const char *stop) {
 	size_t length;
@@ -105,6 +137,10 @@ strcspn (const char *string, const char *stop) {
 	return length;
 }
 
+/* @note
+ * STRING에서 STOP에도 포함된 첫 문자를 가리키는 포인터를 반환한다.
+ * STRING의 어떤 문자도 STOP에 없으면 널 포인터를 반환한다.
+ */
 char *
 strpbrk (const char *string, const char *stop) {
 	for (; *string != '\0'; string++)
@@ -113,6 +149,10 @@ strpbrk (const char *string, const char *stop) {
 	return NULL;
 }
 
+/* @note
+ * STRING에서 C가 마지막으로 나타나는 위치를 가리키는 포인터를 반환한다.
+ * C가 STRING에 없으면 널 포인터를 반환한다.
+ */
 char *
 strrchr (const char *string, int c_) {
 	char c = c_;
@@ -124,6 +164,10 @@ strrchr (const char *string, int c_) {
 	return (char *) p;
 }
 
+/* @note
+ * STRING의 앞부분에서 SKIP에 포함된 문자들로만 이루어진
+ * 초기 부분 문자열의 길이를 반환한다.
+ */
 size_t
 strspn (const char *string, const char *skip) {
 	size_t length;
@@ -134,6 +178,11 @@ strspn (const char *string, const char *skip) {
 	return length;
 }
 
+/* @note
+ * HAYSTACK 안에서 NEEDLE이 처음 나타나는 위치를 가리키는 포인터를
+ * 반환한다.
+ * HAYSTACK 안에 NEEDLE이 없으면 널 포인터를 반환한다.
+ */
 char *
 strstr (const char *haystack, const char *needle) {
 	size_t haystack_len = strlen (haystack);
@@ -150,6 +199,38 @@ strstr (const char *haystack, const char *needle) {
 	return NULL;
 }
 
+/* @note
+ * DELIMITERS로 구분된 토큰들로 문자열을 나눈다.
+ * 이 함수를 처음 호출할 때는 S에 토큰화할 문자열을 넘겨야 하고,
+ * 그 이후 호출에서는 S가 널 포인터여야 한다.
+ * SAVE_PTR은 토크나이저의 현재 위치를 추적하는 `char *` 변수의 주소다.
+ * 각 호출의 반환값은 문자열의 다음 토큰이며,
+ * 남은 토큰이 없으면 널 포인터를 반환한다.
+ *
+ * 이 함수는 연속된 여러 구분자를 하나의 구분자로 취급한다.
+ * 반환되는 토큰의 길이는 절대 0이 아니다.
+ * 하나의 문자열을 처리하는 동안에는 호출마다 DELIMITERS가 달라도 된다.
+ *
+ * strtok_r()는 문자열 S를 수정해 구분자를 널 바이트로 바꾼다.
+ * 따라서 S는 수정 가능한 문자열이어야 한다.
+ * 특히 문자열 리터럴은, 하위 호환 때문에 `const`가 아니더라도,
+ * C에서 수정할 수 없다.
+ *
+ * 사용 예:
+ *
+ * char s[] = "  String to  tokenize. ";
+ * char *token, *save_ptr;
+ *
+ * for (token = strtok_r (s, " ", &save_ptr); token != NULL;
+ *      token = strtok_r (NULL, " ", &save_ptr))
+ *   printf ("'%s'\n", token);
+ *
+ * 출력:
+ *
+ * 'String'
+ * 'to'
+ * 'tokenize.'
+ */
 char *
 strtok_r (char *s, const char *delimiters, char **save_ptr) {
 	char *token;
@@ -157,11 +238,21 @@ strtok_r (char *s, const char *delimiters, char **save_ptr) {
 	ASSERT (delimiters != NULL);
 	ASSERT (save_ptr != NULL);
 
+	/* @note
+	 * S가 널이 아니면 S부터 시작하고, 널이면 저장된 위치부터 시작한다.
+	 */
 	if (s == NULL)
 		s = *save_ptr;
 	ASSERT (s != NULL);
 
+	/* @note
+	 * 현재 위치에서 DELIMITERS에 포함된 문자를 모두 건너뛴다.
+	 */
 	while (strchr (delimiters, *s) != NULL) {
+		/* @note
+		 * 문자열은 끝에 항상 널 바이트를 가지므로,
+		 * 널 바이트를 찾을 때 strchr()는 항상 널이 아닌 값을 반환한다.
+		 */
 		if (*s == '\0') {
 			*save_ptr = s;
 			return NULL;
@@ -170,6 +261,9 @@ strtok_r (char *s, const char *delimiters, char **save_ptr) {
 		s++;
 	}
 
+	/* @note
+	 * 문자열 끝까지 DELIMITERS에 포함되지 않은 문자를 건너뛴다.
+	 */
 	token = s;
 	while (strchr (delimiters, *s) == NULL)
 		s++;
@@ -181,6 +275,9 @@ strtok_r (char *s, const char *delimiters, char **save_ptr) {
 	return token;
 }
 
+/* @note
+ * DST의 SIZE바이트를 VALUE로 채운다.
+ */
 void *
 memset (void *dst_, int value, size_t size) {
 	unsigned char *dst = dst_;
@@ -193,6 +290,9 @@ memset (void *dst_, int value, size_t size) {
 	return dst_;
 }
 
+/* @note
+ * STRING의 길이를 반환한다.
+ */
 size_t
 strlen (const char *string) {
 	const char *p;
@@ -204,6 +304,10 @@ strlen (const char *string) {
 	return p - string;
 }
 
+/* @note
+ * STRING의 길이가 MAXLEN보다 짧으면 실제 길이를 반환한다.
+ * 그렇지 않으면 MAXLEN을 반환한다.
+ */
 size_t
 strnlen (const char *string, size_t maxlen) {
 	size_t length;
@@ -213,6 +317,17 @@ strnlen (const char *string, size_t maxlen) {
 	return length;
 }
 
+/* @note
+ * 문자열 SRC를 DST로 복사한다.
+ * SRC가 SIZE - 1보다 길면 앞의 SIZE - 1글자만 복사한다.
+ * SIZE가 0이 아닌 한, DST에는 항상 널 종료 문자가 기록된다.
+ * 널 종료 문자를 제외한 SRC의 길이를 반환한다.
+ *
+ * strlcpy()는 표준 C 라이브러리에 포함되어 있지 않지만,
+ * 점점 널리 쓰이는 확장이다.
+ * strlcpy()에 대한 정보는
+ * http://www.courtesan.com/todd/papers/strlcpy.html 를 참고하라.
+ */
 size_t
 strlcpy (char *dst, const char *src, size_t size) {
 	size_t src_len;
@@ -231,6 +346,18 @@ strlcpy (char *dst, const char *src, size_t size) {
 	return src_len;
 }
 
+/* @note
+ * 문자열 SRC를 DST 뒤에 이어 붙인다.
+ * 이어 붙인 결과 문자열은 최대 SIZE - 1글자로 제한된다.
+ * SIZE가 0이 아닌 한, DST에는 항상 널 종료 문자가 기록된다.
+ * 공간이 충분하다고 가정했을 때 만들어졌을 전체 문자열 길이를,
+ * 널 종료 문자를 제외하고 반환한다.
+ *
+ * strlcat()는 표준 C 라이브러리에 포함되어 있지 않지만,
+ * 점점 널리 쓰이는 확장이다.
+ * strlcpy()에 대한 정보는
+ * http://www.courtesan.com/todd/papers/strlcpy.html 를 참고하라.
+ */
 size_t
 strlcat (char *dst, const char *src, size_t size) {
 	size_t src_len, dst_len;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -29,7 +29,8 @@
 
 /* 보조 함수 선언부. */
 static bool cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *aux);
-bool thread_priority_d_elem(const struct list_elem *a, const struct list_elem *b, void *aux);
+bool thread_priority_donation_elem(const struct list_elem *a,
+                                   const struct list_elem *b, void *aux);
 
 /*
  * 세마포어 SEMA를 VALUE로 초기화한다.
@@ -211,9 +212,10 @@ lock_acquire (struct lock *lock) {
 		int idx = 0;
 		
 		/* holder의 donation_list에 추가하기: 내림차순 */
-		list_insert_ordered(&holder->donation_list, &curr->d_elem, thread_priority_d_elem, NULL);
+		list_insert_ordered(&holder->donation_list, &curr->donation_elem,
+		                    thread_priority_donation_elem, NULL);
 		/* 내가 누구에 의해 lock 되었는지 명시하기 */
-		curr->locked_by = lock;
+		curr->waiting_lock = lock;
 		
 		/* 만약 lock 소유 스레드의 priority가 낮다면? => 기부 */
 		if(holder->priority < curr->priority){
@@ -222,7 +224,7 @@ lock_acquire (struct lock *lock) {
 
 		/* 일단 임시로 여기에 중첩 기부를 넣기로... */
 		while(idx < 7){
-			struct lock *next_lock = holder->locked_by;
+			struct lock *next_lock = holder->waiting_lock;
 			if(next_lock == NULL) break;
 			holder = next_lock->holder;
 			
@@ -238,8 +240,8 @@ lock_acquire (struct lock *lock) {
 
 	/* 단순히 sema_val을 낮출 뿐만 아니라, lock 획득을 위한 대기함(wait에 넣기) */
 	sema_down (&lock->semaphore);
-	/* 여기선 락을 획득했으니까, locked_by를 null 처리 */
-	curr->locked_by = NULL;
+	/* 여기선 락을 획득했으니까, waiting_lock을 null 처리 */
+	curr->waiting_lock = NULL;
 	lock->holder = thread_current ();
 }
 
@@ -284,12 +286,12 @@ lock_release (struct lock *lock) {
 	struct list_elem *d_e = list_begin(d_list);
 	
 	while(d_e != list_end(d_list)){
-		struct thread *d_t = list_entry(d_e, struct thread, d_elem);
+		struct thread *d_t = list_entry(d_e, struct thread, donation_elem);
 		/* 순회 꼬이지 않도록 미리미리 다음 것 확보하기 */
 		struct list_elem *next = list_next(d_e);
 
 		/* 이 스레드가 어떤 lock에 의해 대기타는지 확인 => 같은 lock이면 제거 */
-		if(d_t->locked_by == lock){
+		if(d_t->waiting_lock == lock){
 			list_remove(d_e);
 		}
 
@@ -433,10 +435,11 @@ cmp_sema_priority(const struct list_elem *a, const struct list_elem *b, void *au
 	return ta->priority > tb->priority;
 }
 
-/* d_elem 기준 priority 구하기 */
+/* donation_elem 기준 priority 구하기 */
 bool
-thread_priority_d_elem(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED){
+thread_priority_donation_elem(const struct list_elem *a,
+                              const struct list_elem *b, void *aux UNUSED){
 	/* 이번에는 좀 더 간결하게 표현 */
-	return list_entry(a, struct thread, d_elem)->priority > 
-		   list_entry(b, struct thread, d_elem)->priority;
+	return list_entry(a, struct thread, donation_elem)->priority >
+		   list_entry(b, struct thread, donation_elem)->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -515,24 +515,19 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->base_priority = priority;
 	t->priority = priority;
-	t->exit_status = -1;
 	t->magic = THREAD_MAGIC;
-	sema_init (&t->wait_sema, 0);
-	sema_init (&t->exit_sema, 0);
-	list_init (&t->children);
 
 	/* phase 3: priority donation 추가 구현 변수 초기화 */
 	list_init (&t->donation_list);
 	t->waiting_lock = NULL;
 
 #ifdef USERPROG
-	/* @todo
-	 * fd_table: palloc으로 1페이지(4KB) 할당하여 512개 슬롯 확보.
-	 * memset으로 전부 NULL 초기화.
-	 * next_fd = 2 (0=stdin, 1=stdout 예약). */
-	t->fd_table = palloc_get_page (PAL_ZERO);
-	t->next_fd = 2;
+	t->fd_table = palloc_get_page (PAL_ZERO); // fd 테이블용 페이지 할당 및 0 초기화
+	t->next_fd = 2;                           // 0, 1은 stdin/stdout 예약
+	list_init (&t->child_status_list);        // 자식 상태 레코드 리스트 초기화
+	t->self_status = NULL;                    // 아직 연결된 child_status 없음
 #endif
+
 }
 
 /*

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -257,6 +257,9 @@ thread_create (const char *name, int priority, thread_func *function,
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
+	/* @breakpoint
+	* (void *) t->tf.R.rip, (void *) t->tf.R.rdi, (char *) t->tf.R.rsi
+	*/
 	/*
 	 * 새 스레드를 스케줄러 ready_list 추가
 	 */
@@ -519,6 +522,10 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->locked_by = NULL;
 
 #ifdef USERPROG
+	/* @todo
+	 * fd_table: palloc으로 1페이지(4KB) 할당하여 512개 슬롯 확보.
+	 * memset으로 전부 NULL 초기화.
+	 * next_fd = 2 (0=stdin, 1=stdout 예약). */
 	t->fd_table = palloc_get_page (PAL_ZERO);
 	t->next_fd = 2;
 #endif
@@ -540,6 +547,9 @@ next_thread_to_run (void) {
 
 /*
  * iretq를 사용해 스레드를 시작한다.
+ */
+/* @bookmark
+ * do_iret - 스레드를 시작
  */
 void
 do_iret (struct intr_frame *tf) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -514,12 +514,16 @@ init_thread (struct thread *t, const char *name, int priority) {
 	strlcpy (t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->base_priority = priority;
+	t->priority = priority;
+	t->exit_status = -1;
 	t->magic = THREAD_MAGIC;
+	sema_init (&t->wait_sema, 0);
+	sema_init (&t->exit_sema, 0);
+	list_init (&t->children);
 
 	/* phase 3: priority donation 추가 구현 변수 초기화 */
 	list_init (&t->donation_list);
-	t->priority = priority;
-	t->locked_by = NULL;
+	t->waiting_lock = NULL;
 
 #ifdef USERPROG
 	/* @todo
@@ -797,9 +801,9 @@ refresh_priority (struct thread *t) {
 	t->priority = t->base_priority;
 
 	if (!list_empty (&t->donation_list)) {
-		list_sort (&t->donation_list, thread_priority_d_elem, NULL);
+		list_sort (&t->donation_list, thread_priority_donation_elem, NULL);
 		struct thread *top = list_entry (list_front (&t->donation_list),
-		                                 struct thread, d_elem);
+		                                 struct thread, donation_elem);
 		if (top->priority > t->priority)
 			t->priority = top->priority;
 	}

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -101,6 +101,9 @@ initd (void *f_name) {
 	NOT_REACHED ();
 }
 
+/* @bookmark
+ * process_fork - 스레드 포크
+ */
 /*
  * 현재 프로세스를 `name`이라는 이름으로 복제한다.
  * 새 프로세스의 스레드 id를 반환하고, 스레드를 생성할 수 없으면
@@ -149,6 +152,8 @@ process_fork (const char *name, struct intr_frame *if_) {
 		free (args);
 		return TID_ERROR;
 	}
+
+	sema_down (&cs->wait_sema);
 
 	cs->tid = tid;
 	return tid;
@@ -320,7 +325,7 @@ process_exec (void *f_name) {
  * 이 함수는 문제 2-2에서 구현될 것이다. 현재는 아무 일도 하지 않는다.
  */
 /* @bookmark
- * process_wait: timer_sleep 임시 대기
+ * process_wait: 자식 프로세스 대기
  */
 int
 process_wait (tid_t child_tid UNUSED) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -34,11 +34,17 @@ static void __do_fork (void *);
 /*
  * initd와 다른 프로세스를 위한 일반적인 프로세스 초기화 함수.
  */
+/* @todo
+ * 프로세스를 위한 초기화 함수 (미구현)
+ */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
 }
 
+/* @bookmark
+ * process_create_initd - 프로세스 시작
+ */
 tid_t
 process_create_initd (const char *file_name) {
 	char *file_name_copy;
@@ -71,6 +77,9 @@ process_create_initd (const char *file_name) {
 
 /*
  * 첫 번째 유저 프로세스를 시작하는 스레드 함수.
+ */
+/* @bookmark
+ * initd - 유저 프로세스를 시작
  */
 static void
 initd (void *f_name) {
@@ -117,14 +126,30 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	void *newpage;
 	bool writable;
 
+	/* @todo
+	 * 1. 커널 페이지 필터링:
+	 * is_kernel_vaddr(va)이면 return true로 건너뛴다.
+	 * 커널 영역은 모든 프로세스가 공유하므로 복제 대상이 아니다. */
 
 	/* 2. 부모의 페이지 맵 레벨 4에서 VA를 해석한다. */
 	parent_page = pml4_get_page (parent->pml4, va);
 
+	/* @todo
+	 * 3. 자식용 새 페이지 할당:
+	 * palloc_get_page(PAL_USER)로 유저 영역 페이지 1개를 할당한다.
+	 * 실패하면 return false (메모리 부족, __do_fork의 error로 점프). */
 
+	/* @todo
+	 * 4. 부모 페이지 복사 + 쓰기 권한 확인:
+	 * memcpy(newpage, parent_page, PGSIZE)로 4KB 전체를 복사한다.
+	 * writable = is_writable(pte)로 부모 PTE의 쓰기 비트를 읽는다.
+	 * (include/threads/mmu.h에 매크로 정의됨) */
 
 	/* 5. 자식 페이지 테이블에 매핑 추가. */
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
+		/* @todo
+		 * 6. 실패 시 방금 할당한 newpage를 palloc_free_page로 해제하고
+		 * return false 한다. */
 	}
 	return true;
 }
@@ -149,6 +174,17 @@ __do_fork (void *aux) {
 	struct thread *parent = (struct thread *) aux;
 	struct thread *current = thread_current ();
 
+	/* @todo
+	 * parent_if 전달 문제 해결:
+	 * process_fork()의 if_ (유저랜드 레지스터 스냅샷)를 여기로 전달해야 한다.
+	 * parent->tf는 커널 문맥이므로 쓸 수 없다.
+	 *
+	 * 방법: process_fork에서 if_를 parent의 멤버에 저장하고 여기서 읽는다.
+	 * 예) thread.h에 struct intr_frame parent_if 필드를 추가하거나,
+	 *     process_fork에서 memcpy(&parent->tf, if_)로 임시 저장한 뒤
+	 *     여기서 parent->tf를 읽는다.
+	 *
+	 * 현재: parent_if가 초기화되지 않아 memcpy가 크래시한다. */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
@@ -170,9 +206,41 @@ __do_fork (void *aux) {
 		goto error;
 #endif
 
+	/* @todo
+	 * 3. 부모의 fd_table 복제:
+	 * parent->fd_table을 순회하며(i = 2 ~ FD_MAX) NULL이 아닌 슬롯마다
+	 * file_duplicate(parent->fd_table[i])로 복제하여
+	 * current->fd_table[i]에 저장한다.
+	 * current->next_fd = parent->next_fd로 동기화한다.
+	 *
+	 * file_duplicate는 inode 참조 카운트를 증가시키는 함수다.
+	 * 단순히 포인터를 복사하면 부모/자식이 같은 file 객체를 공유하게 되어
+	 * 한쪽이 close하면 다른 쪽도 닫혀버린다. */
 
+	/* @todo
+	 * 4. 자식의 fork 반환값 설정:
+	 * if_.R.rax = 0 으로 설정한다.
+	 * fork()는 부모에게 자식 tid를, 자식에게 0을 반환해야 한다.
+	 * 부모의 반환값은 process_fork가 thread_create의 tid를 반환하므로 자동.
+	 * 자식은 여기서 rax를 0으로 덮어써야 한다. */
 
+	/* @todo
+	 * 5. 자식의 child_list 재초기화:
+	 * memcpy로 부모의 메모리를 복사하면 child_list 포인터까지 복사된다.
+	 * 자식은 자기만의 빈 child_list를 가져야 하므로
+	 * list_init(&current->child_list)로 재초기화한다.
+	 * parent 포인터도 이미 thread_create에서 설정되어 있으므로 확인만 한다. */
 
+	/* @todo
+	 * 6. 부모-자식 동기화 (fork 완료 알림):
+	 * 힌트의 핵심: "이 함수가 부모의 자원을 성공적으로 복제하기 전까지
+	 * 부모는 fork()에서 반환되면 안 된다."
+	 *
+	 * 방법: 세마포어를 하나 추가한다 (예: fork_sema).
+	 *   - process_fork에서 thread_create 후 sema_down(&curr->fork_sema)
+	 *   - __do_fork에서 복제 완료 후 sema_up(&parent->fork_sema)
+	 *   - 실패(error) 시에도 sema_up 해서 부모가 깨어나야 한다.
+	 *   - 부모는 깨어난 후 성공/실패를 확인하여 tid 또는 TID_ERROR 반환. */
 
 	process_init ();
 
@@ -180,12 +248,19 @@ __do_fork (void *aux) {
 	if (succ)
 		do_iret (&if_);
 error:
+	/* @todo
+	 * 실패 시 처리:
+	 * succ = false 설정 후, 부모에게 실패를 알려야 한다.
+	 * (fork_sema를 사용한다면 여기서도 sema_up 필요) */
 	thread_exit ();
 }
 
 /*
  * 현재 실행 문맥을 f_name으로 전환한다.
  * 실패하면 -1을 반환한다.
+ */
+/* @bookmark
+ * process_exec - 바이너리 로드 후 유저 모드 전환
  */
 int
 process_exec (void *f_name) {
@@ -207,6 +282,9 @@ process_exec (void *f_name) {
 
 	/*
 	 * 먼저 현재 문맥을 제거한다.
+	 */
+	/* @todo
+	 * 이전 주소 공간 초기화 (미구현)
 	 */
 	process_cleanup ();
 
@@ -240,6 +318,9 @@ process_exec (void *f_name) {
  *
  * 이 함수는 문제 2-2에서 구현될 것이다. 현재는 아무 일도 하지 않는다.
  */
+/* @bookmark
+ * process_wait: timer_sleep 임시 대기
+ */
 int
 process_wait (tid_t child_tid UNUSED) {
 	/*
@@ -262,13 +343,41 @@ void
 process_exit (void) {
 	struct thread *curr = thread_current ();
 
+	/* @todo
+	 * 열린 파일 전부 닫기:
+	 * fd_table을 2번부터 FD_MAX까지 순회하며
+	 * NULL이 아닌 슬롯은 file_close() 호출 후 NULL로 비운다. */
 
+	/* @todo
+	 * fd_table 페이지 해제:
+	 * palloc_free_page(curr->fd_table)로 반환한다. */
 
+	/* @todo
+	 * 고아 해방 루프:
+	 * child_list를 순회하며 wait하지 않은 자식들의
+	 * exit_sema를 sema_up해서 소멸을 허가한다. */
 
+	/* @todo
+	 * 부모에게 종료 알림 (유저 프로세스만):
+	 * if (curr->pml4 != NULL)
+	 *   sema_up(&curr->wait_sema) -- 부모 깨우기
+	 *   sema_down(&curr->exit_sema) -- 부모 수거 대기 */
 
 	process_cleanup ();
 }
 
+/* @todo
+ * process_add_file - 파일을 fd_table에 등록하고 fd 번호를 반환한다.
+ *
+ * 구현해야 할 것:
+ * 1. curr->next_fd가 FD_MAX 이상이면 -1 반환 (테이블 꽉 참).
+ * 2. curr->fd_table[curr->next_fd] = f 로 저장.
+ * 3. curr->next_fd를 반환값으로 쓰고, next_fd++ 증가.
+ * 4. 반환한 fd 번호를 돌려준다.
+ *
+ * 주의: 중간에 close로 빈 슬롯이 생기면 next_fd 방식은
+ * 그 빈 자리를 재활용하지 못한다. 단순 구현에서는 괜찮지만,
+ * multi-oom 테스트를 통과하려면 빈 슬롯 탐색이 필요할 수 있다. */
 int
 process_add_file (struct file *f) {
 	struct thread *curr = thread_current ();
@@ -277,6 +386,12 @@ process_add_file (struct file *f) {
 	return -1;
 }
 
+/* @todo
+ * process_get_file - fd 번호로 파일 포인터를 반환한다.
+ *
+ * 구현해야 할 것:
+ * 1. fd가 범위 밖이면 (fd < 0 || fd >= FD_MAX) NULL 반환.
+ * 2. curr->fd_table[fd]를 반환한다 (NULL이면 열리지 않은 fd). */
 struct file *
 process_get_file (int fd) {
 	struct thread *curr = thread_current ();
@@ -285,6 +400,14 @@ process_get_file (int fd) {
 	return NULL;
 }
 
+/* @todo
+ * process_close_file - fd를 닫고 fd_table에서 제거한다.
+ *
+ * 구현해야 할 것:
+ * 1. fd가 범위 밖이면 (fd < 2 || fd >= FD_MAX) 무시 (0,1은 예약).
+ * 2. curr->fd_table[fd]가 NULL이면 무시.
+ * 3. file_close(curr->fd_table[fd]) 호출.
+ * 4. curr->fd_table[fd] = NULL로 비운다. */
 void
 process_close_file (int fd) {
 	struct thread *curr = thread_current ();
@@ -474,6 +597,9 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
  * 초기 스택 포인터를 *RSP에 저장한다.
  * 성공하면 true, 그렇지 않으면 false를 반환한다.
  */
+/* @bookmark
+ * load - 실행 파일의 진입점
+ */
 static bool
 load (const char *file_name, struct intr_frame *if_) {
 	struct thread *t = thread_current ();
@@ -505,6 +631,9 @@ load (const char *file_name, struct intr_frame *if_) {
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return false;
+	/* @breakpoint
+	 * (cahr *) file_name
+	 */
 	memcpy (fn_copy, file_name, CSTR_SIZE (file_name));
 
 	/*
@@ -533,6 +662,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	/*
 	 * 실행 파일 헤더를 읽고 검증한다.
 	 */
+	/* @region ELF 헤더 검사 - 실행 가능한 ELF 파일 형식 확인 */
 	/*
 	 * e_ident    : ELF 파일 여부, 64비트 여부, 엔디안 정보
 	 *              \177ELF = ELF 매직 값
@@ -553,10 +683,12 @@ load (const char *file_name, struct intr_frame *if_) {
 		printf ("load: %s: error loading executable\n", file_name);
 		goto done;
 	}
+	/* @endregion */
 
 	/*
 	 * 프로그램 헤더들을 읽는다.
 	 */
+	/* @region 프로그램 헤더 표 순회 - 메모리에 올릴 파일 구역 설명서 읽기 */
 	/*
 	 * e_phoff : 파일 시작 기준 프로그램 헤더 표 시작 위치
 	 * e_phnum : 프로그램 헤더 개수
@@ -576,6 +708,9 @@ load (const char *file_name, struct intr_frame *if_) {
 			goto done;
 		file_seek (file, file_ofs);
 
+		/*
+		 * 현재 프로그램 헤더 1개를 읽고 다음 헤더 위치로 이동
+		 */
 		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr)
 			goto done;
 		file_ofs += sizeof phdr;
@@ -660,10 +795,12 @@ load (const char *file_name, struct intr_frame *if_) {
 			break;
 		}
 	}
+	/* @endregion */
 
 	/*
 	 * 스택을 설정한다.
 	 */
+	/* @region 유저 스택 구성 - 인자 문자열, argv 배열, 시작 레지스터 준비 */
 	if (!setup_stack (if_))
 		goto done;
 
@@ -705,6 +842,9 @@ load (const char *file_name, struct intr_frame *if_) {
 	 */
 	stack_p = (char *) ((uintptr_t) stack_p & -8);
 
+	/*
+	 * argv[argc] = NULL 자리
+	 */
 	stack_p -= 8;
 	memset (stack_p, 0, 8);
 	/*
@@ -747,6 +887,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	/*
 	 * if_->rsp = 유저 프로그램 시작 시 사용할 스택 포인터
 	 */
+	/* @endregion */
 
 	// hex_dump(if_->rsp, if_->rsp, USER_STACK - (uint64_t)if_->rsp, true);
 	success = true;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -29,9 +29,9 @@ static void initd (void *f_name);
 static void __do_fork (void *);
 
 struct fork_args {
-	struct thread *parent;        // fork를 호출한 부모 스레드
-	struct intr_frame if_;        // 부모의 유저 레지스터 스냅샷
-	struct child_status *cs;      // 부모가 만든 자식 상태 레코드
+	struct thread *parent;   // fork를 호출한 부모 스레드
+	struct intr_frame if_;   // 부모의 유저 레지스터 스냅샷
+	struct child_status *cs; // 부모가 만든 자식 상태 레코드
 };
 
 /* fd_table 최대 슬롯 수 (4KB 페이지 / 포인터 크기). */
@@ -107,11 +107,15 @@ initd (void *f_name) {
  * TID_ERROR를 반환한다.
  */
 tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
+process_fork (const char *name, struct intr_frame *if_) {
 	struct thread *curr = thread_current ();
 	struct child_status *cs;
+	struct fork_args *args;
 	tid_t tid;
 
+	/* @note
+	 * 자식 스레드를 기다리기 위한 구조체
+	 */
 	cs = malloc (sizeof *cs);
 	if (cs == NULL)
 		return TID_ERROR;
@@ -124,11 +128,29 @@ process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 
 	list_push_back (&curr->child_status_list, &cs->elem);
 
-	tid = thread_create (name, PRI_DEFAULT, __do_fork, thread_current ());
+	/* @note
+	 * 스레드 포크를 위한 정보 구조체
+	 */
+	args = malloc (sizeof *args);
+	if (args == NULL) {
+		list_remove (&cs->elem);
+		free (cs);
+		return TID_ERROR;
+	}
+
+	args->parent = curr;
+	args->if_ = *if_;
+	args->cs = cs;
+
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, args);
 	if (tid == TID_ERROR) {
 		list_remove (&cs->elem);
 		free (cs);
+		free (args);
+		return TID_ERROR;
 	}
+
+	cs->tid = tid;
 	return tid;
 }
 
@@ -195,88 +217,42 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *   5. 부모에게 "복제 완료" 알림, do_iret으로 유저 모드 진입 */
 static void
 __do_fork (void *aux) {
+	struct fork_args *args = aux;
+	struct thread *curr = thread_current ();
+	struct thread *parent = args->parent;
 	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
-	struct thread *current = thread_current ();
 
-	/* @todo
-	 * parent_if 전달 문제 해결:
-	 * process_fork()의 if_ (유저랜드 레지스터 스냅샷)를 여기로 전달해야 한다.
-	 * parent->tf는 커널 문맥이므로 쓸 수 없다.
-	 *
-	 * 방법: process_fork에서 if_를 parent의 멤버에 저장하고 여기서 읽는다.
-	 * 예) thread.h에 struct intr_frame parent_if 필드를 추가하거나,
-	 *     process_fork에서 memcpy(&parent->tf, if_)로 임시 저장한 뒤
-	 *     여기서 parent->tf를 읽는다.
-	 *
-	 * 현재: parent_if가 초기화되지 않아 memcpy가 크래시한다. */
-	struct intr_frame *parent_if;
-	bool succ = true;
+	curr->self_status = args->cs;
+	memcpy (&if_, &args->if_, sizeof if_);
+	free (args);
 
-	/* 1. CPU 문맥(레지스터)을 로컬 스택으로 복사한다. */
-	memcpy (&if_, parent_if, sizeof (struct intr_frame));
-
-	/* 2. 페이지 테이블을 복제한다. */
-	current->pml4 = pml4_create ();
-	if (current->pml4 == NULL)
+	curr->pml4 = pml4_create ();
+	if (curr->pml4 == NULL)
 		goto error;
 
-	process_activate (current);
+	process_activate (curr);
 #ifdef VM
-	supplemental_page_table_init (&current->spt);
-	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
+	supplemental_page_table_init (&curr->spt);
+	if (!supplemental_page_table_copy (&curr->spt, &parent->spt))
 		goto error;
 #else
 	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
 		goto error;
 #endif
 
-	/* @todo
-	 * 3. 부모의 fd_table 복제:
-	 * parent->fd_table을 순회하며(i = 2 ~ FD_MAX) NULL이 아닌 슬롯마다
-	 * file_duplicate(parent->fd_table[i])로 복제하여
-	 * current->fd_table[i]에 저장한다.
-	 * current->next_fd = parent->next_fd로 동기화한다.
-	 *
-	 * file_duplicate는 inode 참조 카운트를 증가시키는 함수다.
-	 * 단순히 포인터를 복사하면 부모/자식이 같은 file 객체를 공유하게 되어
-	 * 한쪽이 close하면 다른 쪽도 닫혀버린다. */
-
-	/* @todo
-	 * 4. 자식의 fork 반환값 설정:
-	 * if_.R.rax = 0 으로 설정한다.
-	 * fork()는 부모에게 자식 tid를, 자식에게 0을 반환해야 한다.
-	 * 부모의 반환값은 process_fork가 thread_create의 tid를 반환하므로 자동.
-	 * 자식은 여기서 rax를 0으로 덮어써야 한다. */
-
-	/* @todo
-	 * 5. 자식의 child_list 재초기화:
-	 * memcpy로 부모의 메모리를 복사하면 child_list 포인터까지 복사된다.
-	 * 자식은 자기만의 빈 child_list를 가져야 하므로
-	 * list_init(&current->child_list)로 재초기화한다.
-	 * parent 포인터도 이미 thread_create에서 설정되어 있으므로 확인만 한다. */
-
-	/* @todo
-	 * 6. 부모-자식 동기화 (fork 완료 알림):
-	 * 힌트의 핵심: "이 함수가 부모의 자원을 성공적으로 복제하기 전까지
-	 * 부모는 fork()에서 반환되면 안 된다."
-	 *
-	 * 방법: 세마포어를 하나 추가한다 (예: fork_sema).
-	 *   - process_fork에서 thread_create 후 sema_down(&curr->fork_sema)
-	 *   - __do_fork에서 복제 완료 후 sema_up(&parent->fork_sema)
-	 *   - 실패(error) 시에도 sema_up 해서 부모가 깨어나야 한다.
-	 *   - 부모는 깨어난 후 성공/실패를 확인하여 tid 또는 TID_ERROR 반환. */
+	/* 자식 프로세스에서 fork()의 반환값은 0이다. */
+	if_.R.rax = 0;
 
 	process_init ();
 
 	/* 새로 생성된 프로세스로 전환한다. */
-	if (succ)
-		do_iret (&if_);
+	do_iret (&if_);
 error:
-	/* @todo
-	 * 실패 시 처리:
-	 * succ = false 설정 후, 부모에게 실패를 알려야 한다.
-	 * (fork_sema를 사용한다면 여기서도 sema_up 필요) */
+	if (curr->self_status != NULL) {
+		curr->self_status->exit_status = -1;
+		curr->self_status->exited = true;
+		sema_up (&curr->self_status->wait_sema);
+	}
 	thread_exit ();
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -28,6 +28,12 @@ static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
+struct fork_args {
+	struct thread *parent;        // fork를 호출한 부모 스레드
+	struct intr_frame if_;        // 부모의 유저 레지스터 스냅샷
+	struct child_status *cs;      // 부모가 만든 자식 상태 레코드
+};
+
 /* fd_table 최대 슬롯 수 (4KB 페이지 / 포인터 크기). */
 #define FD_MAX (PGSIZE / sizeof (struct file *))
 
@@ -102,10 +108,28 @@ initd (void *f_name) {
  */
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/*
-	 * 현재 스레드를 새 스레드로 복제한다.
-	 */
-	return thread_create (name, PRI_DEFAULT, __do_fork, thread_current ());
+	struct thread *curr = thread_current ();
+	struct child_status *cs;
+	tid_t tid;
+
+	cs = malloc (sizeof *cs);
+	if (cs == NULL)
+		return TID_ERROR;
+
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	cs->exited = false;
+	sema_init (&cs->wait_sema, 0);
+
+	list_push_back (&curr->child_status_list, &cs->elem);
+
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, thread_current ());
+	if (tid == TID_ERROR) {
+		list_remove (&cs->elem);
+		free (cs);
+	}
+	return tid;
 }
 
 #ifndef VM

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -69,6 +69,7 @@ process_create_initd (const char *file_name) {
 	 * 메모리 첫번째 공백까지의 문자열을 스레드 이름으로 사용, 위에서 할당한
 	 * 커널 페이지 주소(새 스레드 시작 함수 인자) 전달
 	 */
+
 	tid = thread_create (program_name, PRI_DEFAULT, initd, file_name_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (file_name_copy);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -100,7 +100,6 @@ exit (int status) {
 	thread_exit ();
 }
 
-
 int
 write (int fd, const void *buffer, unsigned size) {
 	int write_result;


### PR DESCRIPTION
## 변경 개요
포크, exec, wait, 프로세스 라이프사이클 관련 테스트 문서를 추가하고,
관련 프로세스 관리 구조 초안을 함께 정리했습니다.

## 주요 변경
- [pintos-project2-process-tests.md] `테스트 문서` — 포크 및 프로세스 관련 테스트 항목 정리
- [thread.h] `구조체` — `child_status` 구조체 추가
- [thread.h] `enum` — `thread_status` 주석 개선
- [thread.c] `함수` — 스레드 초기화 흐름 정리
- [process.c] `함수` — `fork` 전달 구조와 자식 상태 관리 흐름 초안 추가

## 배경
프로세스 관련 기능의 테스트 범위를 먼저 정리하고,
이후 `fork`, `exec`, `wait`, `exit` 구현 시 필요한 부모-자식 상태 관리 구조를
미리 정리하기 위함입니다.

## 검증
- 프로세스 관련 테스트 문서 항목 정리 확인
- `child_status` 기반 부모-자식 상태 관리 구조 반영 확인
- `fork` 전달 흐름 초안 반영 확인
