### PR TITLE
feat: child_status 기반 wait와 exit 흐름 구현

### DIFF
--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -493,7 +493,7 @@ kernel_thread (thread_func *function, void *aux) {
 	/* 스케줄러는 인터럽트가 꺼진 상태에서 실행된다. */
 	intr_enable ();
 	/* 스레드 함수를 실행한다. */
-function (aux);
+	function (aux);
 	/* function()이 반환하면 스레드를 종료한다. */
 	thread_exit ();
 }
@@ -520,12 +520,11 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 
 #ifdef USERPROG
-	t->fd_table = palloc_get_page (PAL_ZERO); // fd 테이블용 페이지 할당 및 0 초기화
-	t->next_fd = 2;                           // 0, 1은 stdin/stdout 예약
-	list_init (&t->child_status_list);        // 자식 상태 레코드 리스트 초기화
-	t->self_status = NULL;                    // 아직 연결된 child_status 없음
+	t->fd_table = NULL;                    // fd 테이블은 프로세스 로드 시점에 할당
+	t->next_fd = 2;                        // 0, 1은 stdin/stdout 예약
+	list_init (&t->child_status_list);     // 자식 상태 레코드 리스트 초기화
+	t->self_status = NULL;                 // 아직 연결된 child_status 없음
 #endif
-
 }
 
 /*

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -520,7 +520,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 
 #ifdef USERPROG
-	// t->fd_table = palloc_get_page (PAL_ZERO); // fd 테이블용 페이지 할당 및 0 초기화
+	t->fd_table = palloc_get_page (PAL_ZERO); // fd 테이블용 페이지 할당 및 0 초기화
 	t->next_fd = 2;                           // 0, 1은 stdin/stdout 예약
 	list_init (&t->child_status_list);        // 자식 상태 레코드 리스트 초기화
 	t->self_status = NULL;                    // 아직 연결된 child_status 없음

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -62,6 +62,9 @@ process_create_initd (const char *file_name) {
 	struct initd_args *args = NULL;
 	tid_t tid = TID_ERROR;
 
+	if (curr == NULL)
+		return TID_ERROR;
+
 	/*
 	 * 커널 풀에서 페이지 메모리 할당, 0 = 커널 영역(유저 옵션 없음)
 	 */
@@ -122,6 +125,9 @@ initd (void *f_name) {
 	struct initd_args *args = f_name;
 	struct thread *curr = thread_current ();
 
+	if (curr == NULL || args == NULL)
+		thread_exit ();
+
 #ifdef VM
 	supplemental_page_table_init (&curr->spt);
 #endif
@@ -146,6 +152,9 @@ process_fork (const char *name, struct intr_frame *if_) {
 	struct child_status *cs = NULL;
 	struct fork_args *args = NULL;
 	tid_t tid = TID_ERROR;
+
+	if (curr == NULL)
+		return TID_ERROR;
 
 	cs = malloc (sizeof *cs);
 	if (cs == NULL)
@@ -253,8 +262,17 @@ static void
 __do_fork (void *aux) {
 	struct fork_args *args = aux;
 	struct thread *curr = thread_current ();
-	struct thread *parent = args->parent;
+	struct thread *parent;
 	struct intr_frame if_;
+
+	if (curr == NULL || args == NULL)
+		thread_exit ();
+
+	parent = args->parent;
+	if (parent == NULL) {
+		free (args);
+		thread_exit ();
+	}
 
 	curr->self_status = args->cs;
 	memcpy (&if_, &args->if_, sizeof if_);
@@ -301,6 +319,10 @@ int
 process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
+	struct thread *curr = thread_current ();
+
+	if (curr == NULL)
+		return -1;
 
 	/*
 	 * thread 구조체에 있는 intr_frame은 사용할 수 없다.
@@ -321,7 +343,6 @@ process_exec (void *f_name) {
 	process_cleanup ();
 
 	/* 여기서 fd_table 공간 할당 실행 */
-	struct thread *curr = thread_current ();
 	curr->fd_table = palloc_get_page (PAL_ZERO);
 
 	/*
@@ -419,7 +440,7 @@ process_add_file (struct file *f) {
 	struct thread *curr = thread_current ();
 	int fd;
 
-	if (f == NULL || curr->fd_table == NULL)
+	if (curr == NULL || f == NULL || curr->fd_table == NULL)
 		return -1;
 
 	for (fd = 2; fd < FD_MAX; fd++) {
@@ -439,7 +460,7 @@ struct file *
 process_get_file (int fd) {
 	struct thread *curr = thread_current ();
 
-	if (fd < 0 || fd >= FD_MAX || curr->fd_table == NULL)
+	if (curr == NULL || fd < 0 || fd >= FD_MAX || curr->fd_table == NULL)
 		return NULL;
 
 	return curr->fd_table[fd];
@@ -449,7 +470,7 @@ void
 process_close_file (int fd) {
 	struct thread *curr = thread_current ();
 
-	if (fd < 2 || fd >= FD_MAX || curr->fd_table == NULL)
+	if (curr == NULL || fd < 2 || fd >= FD_MAX || curr->fd_table == NULL)
 		return;
 
 	if (curr->fd_table[fd] == NULL)

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -146,7 +146,6 @@ initd (void *f_name) {
  * 새 프로세스의 스레드 id를 반환하고, 스레드를 생성할 수 없으면
  * TID_ERROR를 반환한다.
  */
-// @bookmark process_fork
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
 	struct thread *curr = thread_current ();
@@ -259,7 +258,6 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *   3. 부모의 fd_table 복제 (file_duplicate)
  *   4. 자식의 fork 반환값을 0으로 설정
  *   5. 부모에게 "복제 완료" 알림, do_iret으로 유저 모드 진입 */
-// @bookmark __do_fork
 static void
 __do_fork (void *aux) {
 	struct fork_args *args = aux;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -393,6 +393,9 @@ process_wait (tid_t child_tid) {
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
+	if (curr == NULL)
+		return;
+
 	int fd;
 
 	for (fd = 2; fd < FD_MAX; fd++)

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -146,6 +146,7 @@ initd (void *f_name) {
  * 새 프로세스의 스레드 id를 반환하고, 스레드를 생성할 수 없으면
  * TID_ERROR를 반환한다.
  */
+// @bookmark process_fork
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
 	struct thread *curr = thread_current ();
@@ -258,6 +259,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *   3. 부모의 fd_table 복제 (file_duplicate)
  *   4. 자식의 fork 반환값을 0으로 설정
  *   5. 부모에게 "복제 완료" 알림, do_iret으로 유저 모드 진입 */
+// @bookmark __do_fork
 static void
 __do_fork (void *aux) {
 	struct fork_args *args = aux;
@@ -303,10 +305,13 @@ __do_fork (void *aux) {
 	do_iret (&if_);
 error:
 	if (curr->self_status != NULL) {
-		curr->self_status->exit_status = -1;
-		curr->self_status->exited = true;
-		curr->self_status->fork_success = false;
-		sema_up (&curr->self_status->fork_sema);
+		struct child_status *cs = curr->self_status;
+
+		cs->exit_status = -1;
+		cs->exited = true;
+		cs->fork_success = false;
+		curr->self_status = NULL;
+		sema_up (&cs->fork_sema);
 	}
 	thread_exit ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -93,7 +93,7 @@ initd (void *f_name) {
 		PANIC ("Fail to launch initd\n");
 	NOT_REACHED ();
 }
-
+// @bookmark process_fork
 /*
  * 현재 프로세스를 `name`이라는 이름으로 복제한다.
  * 새 프로세스의 스레드 id를 반환하고, 스레드를 생성할 수 없으면
@@ -102,13 +102,13 @@ initd (void *f_name) {
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
 	struct thread *curr = thread_current ();
-	struct child_status *cs;
-	struct fork_args *args;
-	tid_t tid;
+	struct child_status *cs = NULL;
+	struct fork_args *args = NULL;
+	tid_t tid = TID_ERROR;
 
 	cs = malloc (sizeof *cs);
 	if (cs == NULL)
-		return TID_ERROR;
+		goto done;
 
 	cs->tid = TID_ERROR;
 	cs->exit_status = -1;
@@ -121,29 +121,35 @@ process_fork (const char *name, struct intr_frame *if_) {
 	list_push_back (&curr->child_status_list, &cs->elem);
 
 	args = malloc (sizeof *args);
-	if (args == NULL) {
-		list_remove (&cs->elem);
-		free (cs);
-		return TID_ERROR;
-	}
+	if (args == NULL)
+		goto done;
 
 	args->parent = curr;
 	args->if_ = *if_;
 	args->cs = cs;
 
 	tid = thread_create (name, PRI_DEFAULT, __do_fork, args);
-	if (tid == TID_ERROR) {
-		list_remove (&cs->elem);
-		free (cs);
-		free (args);
-		return TID_ERROR;
-	}
+	if (tid == TID_ERROR)
+		goto done;
 
+	args = NULL;
 	cs->tid = tid;
 	sema_down (&cs->fork_sema);
-	if (!cs->fork_success)
-		return TID_ERROR;
+	if (!cs->fork_success) {
+		tid = TID_ERROR;
+		goto done;
+	}
+
 	return tid;
+
+done:
+	if (args != NULL)
+		free (args);
+	if (cs != NULL) {
+		list_remove (&cs->elem);
+		free (cs);
+	}
+	return TID_ERROR;
 }
 
 #ifndef VM

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -93,7 +93,6 @@ initd (void *f_name) {
 		PANIC ("Fail to launch initd\n");
 	NOT_REACHED ();
 }
-// @bookmark process_fork
 /*
  * 현재 프로세스를 `name`이라는 이름으로 복제한다.
  * 새 프로세스의 스레드 id를 반환하고, 스레드를 생성할 수 없으면

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -355,17 +355,35 @@ process_exec (void *f_name) {
  * 이 함수는 문제 2-2에서 구현될 것이다. 현재는 아무 일도 하지 않는다.
  */
 int
-process_wait (tid_t child_tid UNUSED) {
-	/*
-	 * XXX: 힌트) process_wait(initd)를 호출하면 pintos가 종료된다.
-	 * XXX: 따라서 process_wait를 구현하기 전에 여기에 무한 루프를 추가하는
-	 * 것을
-	 * XXX: 권장한다.
-	 */
-	// struct thread *child = thread_current ();
-	timer_sleep (300);
-	// sema_down(&child->wait_sema);
-	// int status = child->exit_status;
+process_wait (tid_t child_tid) {
+	struct thread *curr = thread_current ();
+	int status;
+
+	if (curr == NULL)
+		return -1;
+
+	struct list *childs = &curr->child_status_list;
+	struct list_elem *e;
+	struct child_status *cs;
+	for (e = list_begin (childs); e != list_end (childs); e = list_next (e)) {
+		cs = list_entry (e, struct child_status, elem);
+
+		if (cs->tid != child_tid)
+			continue;
+
+		if (cs->waited)
+			return -1;
+
+		cs->waited = true;
+
+		if (!cs->exited)
+			sema_down (&cs->wait_sema);
+
+		status = cs->exit_status;
+		list_remove (&cs->elem);
+		free (cs);
+		return status;
+	}
 	return -1;
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -36,6 +36,11 @@ struct fork_args {
 	struct child_status *cs; // 부모가 만든 자식 상태 레코드
 };
 
+struct initd_args {
+	char *file_name;         // 실행할 프로그램 이름 복사본
+	struct child_status *cs; // 부모가 만든 자식 상태 레코드
+};
+
 /* fd_table 최대 슬롯 수 (4KB 페이지 / 포인터 크기). */
 #define FD_MAX (PGSIZE / sizeof (struct file *))
 
@@ -49,10 +54,13 @@ process_init (void) {
 
 tid_t
 process_create_initd (const char *file_name) {
+	struct thread *curr = thread_current ();
 	char *file_name_copy;
 	char program_name[THREAD_NAME_MAX];
 	char *arg_start;
-	tid_t tid;
+	struct child_status *cs = NULL;
+	struct initd_args *args = NULL;
+	tid_t tid = TID_ERROR;
 
 	/*
 	 * 커널 풀에서 페이지 메모리 할당, 0 = 커널 영역(유저 옵션 없음)
@@ -67,15 +75,43 @@ process_create_initd (const char *file_name) {
 	if (arg_start != NULL)
 		*arg_start = '\0';
 
-	/*
-	 * 메모리 첫번째 공백까지의 문자열을 스레드 이름으로 사용, 위에서 할당한
-	 * 커널 페이지 주소(새 스레드 시작 함수 인자) 전달
-	 */
+	cs = malloc (sizeof *cs);
+	if (cs == NULL)
+		goto done;
 
-	tid = thread_create (program_name, PRI_DEFAULT, initd, file_name_copy);
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	cs->exited = false;
+	cs->fork_success = false;
+	sema_init (&cs->fork_sema, 0);
+	sema_init (&cs->wait_sema, 0);
+
+	list_push_back (&curr->child_status_list, &cs->elem);
+
+	args = malloc (sizeof *args);
+	if (args == NULL)
+		goto done;
+
+	args->file_name = file_name_copy;
+	args->cs = cs;
+
+	tid = thread_create (program_name, PRI_DEFAULT, initd, args);
+	if (tid == TID_ERROR)
+		goto done;
+
+	cs->tid = tid;
+	return tid;
+done:
+	if (args != NULL)
+		free (args);
 	if (tid == TID_ERROR)
 		palloc_free_page (file_name_copy);
-	return tid;
+	if (cs != NULL) {
+		list_remove (&cs->elem);
+		free (cs);
+	}
+	return TID_ERROR;
 }
 
 /*
@@ -83,14 +119,20 @@ process_create_initd (const char *file_name) {
  */
 static void
 initd (void *f_name) {
+	struct initd_args *args = f_name;
+	struct thread *curr = thread_current ();
+
 #ifdef VM
-	supplemental_page_table_init (&thread_current ()->spt);
+	supplemental_page_table_init (&curr->spt);
 #endif
 
+	curr->self_status = args->cs;
 	process_init ();
+	f_name = args->file_name;
+	free (args);
 
 	if (process_exec (f_name) < 0)
-		PANIC ("Fail to launch initd\n");
+		thread_exit ();
 	NOT_REACHED ();
 }
 /*

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -87,6 +87,9 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	case SYS_FORK:
 		f->R.rax = fork ((const char *) f->R.rdi, f);
 		break;
+	case SYS_WAIT:
+		f->R.rax = process_wait ((tid_t) f->R.rdi);
+		break;
 	case SYS_WRITE:
 		/* fd, buffer, size를 전달받는다. */
 		f->R.rax = write (f->R.rdi, (const void *) f->R.rsi, f->R.rdx);
@@ -116,13 +119,11 @@ halt (void) {
 	power_off ();
 }
 
+// @bookmark fork
 tid_t
-fork (const char *thread_name, struct intr_frame *f) {
-	// check_address (thread_name);
-	// return process_fork (thread_name, f);
-	(void) thread_name;
-	(void) f;
-	return TID_ERROR;
+fork (const char *thread_name, struct intr_frame *if_) {
+	check_address (thread_name);
+	return process_fork (thread_name, if_);
 }
 
 void
@@ -208,6 +209,7 @@ close (int fd) {
 
 /* 여기서부턴 헬퍼 함수 기술 */
 /* 유효성 검사 */
+// @bookmark check_address
 void
 check_address (const void *addr) {
 	struct thread *curr = thread_current ();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -119,7 +119,6 @@ halt (void) {
 	power_off ();
 }
 
-// @bookmark fork
 tid_t
 fork (const char *thread_name, struct intr_frame *if_) {
 	check_address (thread_name);
@@ -209,7 +208,6 @@ close (int fd) {
 
 /* 여기서부턴 헬퍼 함수 기술 */
 /* 유효성 검사 */
-// @bookmark check_address
 void
 check_address (const void *addr) {
 	struct thread *curr = thread_current ();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -127,9 +127,14 @@ fork (const char *thread_name, struct intr_frame *f) {
 
 void
 exit (int status) {
-	printf ("%s: exit(%d)\n", thread_current ()->name, status);
-	if (thread_current ()->self_status != NULL)
-		thread_current ()->self_status->exit_status = status;
+	struct thread *curr = thread_current ();
+
+	if (curr == NULL)
+		thread_exit ();
+
+	printf ("%s: exit(%d)\n", curr->name, status);
+	if (curr->self_status != NULL)
+		curr->self_status->exit_status = status;
 	thread_exit ();
 }
 
@@ -210,6 +215,9 @@ check_address (const void *addr) {
 	if (addr == NULL) {
 		exit (-1);
 	}
+
+	if (curr == NULL || curr->pml4 == NULL)
+		exit (-1);
 
 	/* 커널 영역 침범 여부 */
 	if (!is_user_vaddr (addr)) {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -90,6 +90,9 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	case SYS_WAIT:
 		f->R.rax = process_wait ((tid_t) f->R.rdi);
 		break;
+	case SYS_EXEC:
+		f->R.rax = process_exec ((tid_t) f->R.rdi);
+		break;
 	case SYS_WRITE:
 		/* fd, buffer, size를 전달받는다. */
 		f->R.rax = write (f->R.rdi, (const void *) f->R.rsi, f->R.rdx);


### PR DESCRIPTION
## 변경 개요
`child_status` 기반으로 부모-자식 종료 상태를 추적하도록 정리하고, `wait`/`exit` 생명주기 경로를 연결했습니다.

## 주요 변경
- [pintos/userprog/process.c] `함수` — `process_wait()` 구현 및 `process_exit()` 종료 알림 흐름 정리
- [pintos/userprog/process.c] `함수` — `process_create_initd()`와 `initd()`가 `child_status`를 통해 첫 유저 프로세스를 추적하도록 연결
- [pintos/userprog/process.c] `함수` — `process_fork()`/`__do_fork()` 실패 정리 흐름 단순화 및 실패 시 자식 상태 정리 보강
- [pintos/userprog/syscall.c] `시스템콜` — `SYS_WAIT`, `SYS_EXEC` 연결 및 `fork`/`exit` 경로 보강
- [pintos/threads/thread.c] `초기화` — 부팅 초기 패닉이 나지 않도록 `fd_table` 할당 시점을 뒤로 미루고 포인터만 초기화

## 배경
`wait(pid)`가 실제로 커널의 `process_wait()`까지 연결되지 않던 문제와, 첫 유저 프로세스(`initd`)를 `child_status` 구조로 추적하지 못하던 문제를 함께 정리할 필요가 있었습니다.
또한 초기 스레드 생성 시점의 `fd_table` 할당이 부팅 패닉을 유발해, 관련 초기화 위치를 조정했습니다.

## 검증
- `clang -fsyntax-only`로 아래 파일 문법 확인
  - `pintos/userprog/process.c`
  - `pintos/userprog/syscall.c`
  - `pintos/threads/thread.c`
- 전체 userprog 테스트는 아직 완전 통과 기준으로 검증하지 못했습니다.

## 확인 필요 사항
- `fork`의 부모 `fd_table` 복제는 아직 남아 있어 관련 테스트는 추가 구현이 필요합니다.
- `wait/exit` 경로 중심으로 정리한 PR이며, 남은 syscall 구현 범위는 후속 작업이 필요합니다.